### PR TITLE
chores(ci): force trusty to keep jdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 jdk:
   - oraclejdk8
 after_success:


### PR DESCRIPTION
Lately the CI is failing because TravisCI seems to force everybody to move to Xenial at least.

We are still using java 8 for this build, which is not available on Xenial. Switching back to Trusty should solve the issue.